### PR TITLE
Substring search

### DIFF
--- a/example/src/EmojiInput.js
+++ b/example/src/EmojiInput.js
@@ -63,7 +63,7 @@ const subSearch = (query) => {
     for (key in emojiSynonyms) {
         if (emojiSynonyms[key].some((curr) => {return curr.contains(query)})) { 
             if(emojiLib[key]) {
-                result.push(emojiLib[key].char)
+                result.push(key)
             } else {
                 console.log(key+' not found in emojiLib')
             }
@@ -75,7 +75,6 @@ const subSearch = (query) => {
 class EmojiInput extends React.PureComponent {
     constructor(props) {
         super(props);
-        console.log('emojiSynonyms: '+emojiSynonyms)
 
         if (this.props.enableFrequentlyUsedEmoji) this.getFrequentlyUsedEmoji();
 
@@ -181,13 +180,11 @@ class EmojiInput extends React.PureComponent {
         this.setState({ emptySearchResult: false });
 
         if (query) {
-            let result = _(search(query))
-                .map(({ index }) => emojiLib[emojiMap[emojiArray[index]]])
-                .value();
-            console.log('Query Content: '+query)
-            console.log('Result: '+result)
-            console.log('Subsearch: '+subSearch(query))
-            result = subSearch(query)
+            // let result = _(search(query))
+            //     .map(({ index }) => emojiLib[emojiMap[emojiArray[index]]])
+            //     .value();
+            let result = subSearch(query).map((str) => emojiLib[str])
+            
             if (!result.length) {
                 this.setState({ emptySearchResult: true });
                 if (this.loggingFunction) {

--- a/example/src/EmojiInput.js
+++ b/example/src/EmojiInput.js
@@ -35,6 +35,8 @@ const {
     emojiArray,
 } = require('./emoji-data/compiled');
 
+const emojiSynonyms = require('./emoji-data/emojiSynonyms')
+
 const categoryIcon = {
     fue: props => <Icon name="clock" type="material-community" {...props} />,
     people: props => <Icon name="face" {...props} />,
@@ -56,9 +58,24 @@ const ViewTypes = {
 
 const search = Wade(emojiArray);
 
+const subSearch = (query) => {
+    result = []
+    for (key in emojiSynonyms) {
+        if (emojiSynonyms[key].some((curr) => {return curr.contains(query)})) { 
+            if(emojiLib[key]) {
+                result.push(emojiLib[key].char)
+            } else {
+                console.log(key+' not found in emojiLib')
+            }
+        }
+    }
+    return result
+}
+
 class EmojiInput extends React.PureComponent {
     constructor(props) {
         super(props);
+        console.log('emojiSynonyms: '+emojiSynonyms)
 
         if (this.props.enableFrequentlyUsedEmoji) this.getFrequentlyUsedEmoji();
 
@@ -167,6 +184,10 @@ class EmojiInput extends React.PureComponent {
             let result = _(search(query))
                 .map(({ index }) => emojiLib[emojiMap[emojiArray[index]]])
                 .value();
+            console.log('Query Content: '+query)
+            console.log('Result: '+result)
+            console.log('Subsearch: '+subSearch(query))
+            result = subSearch(query)
             if (!result.length) {
                 this.setState({ emptySearchResult: true });
                 if (this.loggingFunction) {

--- a/src/EmojiInput.js
+++ b/src/EmojiInput.js
@@ -35,6 +35,8 @@ const {
     emojiArray,
 } = require('./emoji-data/compiled');
 
+const emojiSynonyms = require('./emoji-data/emojiSynonyms')
+
 const categoryIcon = {
     fue: props => <Icon name="clock" type="material-community" {...props} />,
     people: props => <Icon name="face" {...props} />,
@@ -55,6 +57,20 @@ const ViewTypes = {
 };
 
 const search = Wade(emojiArray);
+
+const subSearch = (query) => {
+    result = []
+    for (key in emojiSynonyms) {
+        if (emojiSynonyms[key].some((curr) => {return curr.contains(query)})) { 
+            if(emojiLib[key]) {
+                result.push(key)
+            } else {
+                console.log(key+' not found in emojiLib')
+            }
+        }
+    }
+    return result
+}
 
 class EmojiInput extends React.PureComponent {
     constructor(props) {
@@ -164,9 +180,11 @@ class EmojiInput extends React.PureComponent {
         this.setState({ emptySearchResult: false });
 
         if (query) {
-            let result = _(search(query))
-                .map(({ index }) => emojiLib[emojiMap[emojiArray[index]]])
-                .value();
+            // let result = _(search(query))
+            //     .map(({ index }) => emojiLib[emojiMap[emojiArray[index]]])
+            //     .value();
+            let result = subSearch(query).map((str) => emojiLib[str])
+            
             if (!result.length) {
                 this.setState({ emptySearchResult: true });
                 if (this.loggingFunction) {


### PR DESCRIPTION
Implemented a custom searching method returns any emoji who's synonyms contain the substring of the supplied query. 

Compared to the 'wade' search function the results seem to be very similar if not identical. This leads me to believe that wade already uses a similar method for searching. It still may be worthwhile to use this searching method in case we want to further refine it in the future.