### PR TITLE
Don't call RecyclerView methods in setTimeout call when component is already unmounted

### DIFF
--- a/example/src/EmojiInput.js
+++ b/example/src/EmojiInput.js
@@ -173,7 +173,7 @@ class EmojiInput extends React.PureComponent {
         );
 
         this._rowRenderer = this._rowRenderer.bind(this);
-        this.__mounted = false;
+        this._isMounted = false;
 
         this.state = {
             dataProvider: dataProvider.cloneWithRows(this.emoji),
@@ -190,7 +190,7 @@ class EmojiInput extends React.PureComponent {
     }
 
     componentDidMount() {
-        this.__mounted = true;
+        this._isMounted = true;
         this.search();
     }
 
@@ -210,7 +210,7 @@ class EmojiInput extends React.PureComponent {
     }
 
     componentWillUnmount() {
-        this.__mounted = false;
+        this._isMounted = false;
     }
 
     getFrequentlyUsedEmoji = () => {
@@ -264,7 +264,7 @@ class EmojiInput extends React.PureComponent {
             }
             this.emojiRenderer(result);
             setTimeout(() => {
-                if (this.__mounted) {
+                if (this._isMounted) {
                     this._recyclerListView._pendingScrollToOffset = null;
                     this._recyclerListView.scrollToTop(false);
                 }

--- a/example/src/EmojiInput.js
+++ b/example/src/EmojiInput.js
@@ -173,6 +173,7 @@ class EmojiInput extends React.PureComponent {
         );
 
         this._rowRenderer = this._rowRenderer.bind(this);
+        this.__mounted = false;
 
         this.state = {
             dataProvider: dataProvider.cloneWithRows(this.emoji),
@@ -189,6 +190,7 @@ class EmojiInput extends React.PureComponent {
     }
 
     componentDidMount() {
+        this.__mounted = true;
         this.search();
     }
 
@@ -205,6 +207,10 @@ class EmojiInput extends React.PureComponent {
         ) {
             this.search();
         }
+    }
+
+    componentWillUnmount() {
+        this.__mounted = false;
     }
 
     getFrequentlyUsedEmoji = () => {
@@ -258,8 +264,10 @@ class EmojiInput extends React.PureComponent {
             }
             this.emojiRenderer(result);
             setTimeout(() => {
-                this._recyclerListView._pendingScrollToOffset = null;
-                this._recyclerListView.scrollToTop(false);
+                if (this.__mounted) {
+                    this._recyclerListView._pendingScrollToOffset = null;
+                    this._recyclerListView.scrollToTop(false);
+                }
             }, 15);
         } else {
             let fue = _(this.state.frequentlyUsedEmoji)

--- a/src/EmojiInput.js
+++ b/src/EmojiInput.js
@@ -173,7 +173,7 @@ class EmojiInput extends React.PureComponent {
         );
 
         this._rowRenderer = this._rowRenderer.bind(this);
-        this.__mounted = false;
+        this._isMounted = false;
 
         this.state = {
             dataProvider: dataProvider.cloneWithRows(this.emoji),
@@ -190,7 +190,7 @@ class EmojiInput extends React.PureComponent {
     }
 
     componentDidMount() {
-        this.__mounted = true;
+        this._isMounted = true;
         this.search();
     }
 
@@ -210,7 +210,7 @@ class EmojiInput extends React.PureComponent {
     }
 
     componentWillUnmount() {
-        this.__mounted = false;
+        this._isMounted = false;
     }
 
     getFrequentlyUsedEmoji = () => {
@@ -264,7 +264,7 @@ class EmojiInput extends React.PureComponent {
             }
             this.emojiRenderer(result);
             setTimeout(() => {
-                if (this.__mounted) {
+                if (this._isMounted) {
                     this._recyclerListView._pendingScrollToOffset = null;
                     this._recyclerListView.scrollToTop(false);
                 }

--- a/src/EmojiInput.js
+++ b/src/EmojiInput.js
@@ -173,6 +173,7 @@ class EmojiInput extends React.PureComponent {
         );
 
         this._rowRenderer = this._rowRenderer.bind(this);
+        this.__mounted = false;
 
         this.state = {
             dataProvider: dataProvider.cloneWithRows(this.emoji),
@@ -189,6 +190,7 @@ class EmojiInput extends React.PureComponent {
     }
 
     componentDidMount() {
+        this.__mounted = true;
         this.search();
     }
 
@@ -205,6 +207,10 @@ class EmojiInput extends React.PureComponent {
         ) {
             this.search();
         }
+    }
+
+    componentWillUnmount() {
+        this.__mounted = false;
     }
 
     getFrequentlyUsedEmoji = () => {
@@ -258,8 +264,10 @@ class EmojiInput extends React.PureComponent {
             }
             this.emojiRenderer(result);
             setTimeout(() => {
-                this._recyclerListView._pendingScrollToOffset = null;
-                this._recyclerListView.scrollToTop(false);
+                if (this.__mounted) {
+                    this._recyclerListView._pendingScrollToOffset = null;
+                    this._recyclerListView.scrollToTop(false);
+                }
             }, 15);
         } else {
             let fue = _(this.state.frequentlyUsedEmoji)


### PR DESCRIPTION
# Relate to any issue?
Nope

# Breaking change?
Nope

# What this PR does?  
Because the following code is happening in `setTimeout` call:  
```
this._recyclerListView._pendingScrollToOffset = null;
this._recyclerListView.scrollToTop(false);
```
what can happen and actually happen to us is that the component itself might be already unmounted but the `setTimeout` callout will still happen trying to access those fields and crash.
This was happening in following situation:  
1. `React-Native-Emoji-Picker` is opened in Modal Window.
2. User starts typing in `search` input.
3. User immediately hits back button on Android to close the modal.
4. Component gets unmounted but `setTimeout` call is already queued so it will happen anyway.

That `if` just guards access to those fields only if component is still mounted.
