### PR TITLE
[Feature] Add filterFunctions prop to enable emojis filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ npx babel-node scripts/compile.js
 | `resetSearch`                      | Pass this in if you want to clear the the search                                    | boolean       | false          |
 | `loggingFunction`                  | Logging function to be called when applicable.\*                                    | function      | none           |
 | `verboseLoggingFunction`           | Same as loggingFunction but also provides strategy used to determine failed search  | boolean       | false          |
-
+| `filterFunctions`                  | Array of functions that are used to limit which emojis should be rendered. Each of this function will be invoked with single parameter being `emoji` data and if every function returns `true` for `emoji` then this emoji will be included and displayed.| Array(function) | []  |
 > \* When the search function yields this function is called. Additionally when the user clears the query box this function is called with the previous longest query since the last time the query box was empty. By default the function is called with one parameter, a string representing the query. If the verbose logging function parameter is set to true the function is called with a second parameter that is a string specifying why the function was called (either 'emptySearchResult' or 'longestPreviousQuery').
 
 ## Usage
@@ -88,3 +88,31 @@ Finally compile the data file that used in the keyboard.
 ```shell
 node-babel ./scripts/compile.js
 ```
+
+## Missing Emojis on some devices
+
+So why Emojis are displayed as `X` / other characters insetad of actual Emojis for some of your users?  
+That is because this library renders Emojis based on Font and Font need to support Emoji character in order to render it. And those fonts are updated with every system release, but because there is a lot of Android device manufacturers who are actually using Android as a base to come up with their own UI layer then it is harder for them to keep up with system updates.  
+You can read more about it here [Emojipedia article link](https://blog.emojipedia.org/androids-emoji-problem/)  
+
+So what can you do?  
+Apps such as `Slack` / `WhatsApp` are actually providing Emojis as little images so that they can be render regardless of operating system on mobile phone. The problem in `React-Native` is that there is no support for placing images in `Input` element at time of writing this.  
+Other solution is to limit number of possible emojis to most basic ones which are supported on most devices. Choosing emojis from `Unicode 6.0` seems like solid solution: [Unicode 6.0 Emojis List](https://emojipedia.org/unicode-6.0/) - you get tons of Emojis that are most likely to be correctly rendered across most of the devices.  
+
+In `React-Native-Emoji-Input` you can limit emojis displayed by using `filterFunctions` prop and passing array of functions. Each of this function takes `emoji` as an single parameter and if every function passed in `filterFunctions` prop returns `true` then emoji will be included in final list.  
+We can use that to show only emojis which are part of `Unicode 6.0` or `Unicode 6.1` like so:  
+```
+	filterFunctionByUnicode = emoji => {
+		return emoji.lib.added_in === "6.0" || emoji.lib.added_in === "6.1"
+	}
+
+	<EmojiInput
+		onEmojiSelected={this.handleEmojiSelected}
+		ref={emojiInput => this._emojiInput = emojiInput}
+		resetSearch={this.state.reset}
+		loggingFunction={this.verboseLoggingFunction.bind(this)}
+		verboseLoggingFunction={true}
+		filterFunctions={[this.filterFunctionByUnicode]}
+	/>
+```
+This will render only emojis from Unicode 6.0 and Unicode 6.1 in input.

--- a/example/src/EmojiInput.js
+++ b/example/src/EmojiInput.js
@@ -287,6 +287,9 @@ class EmojiInput extends React.PureComponent {
             return e1.char !== e2.char;
         });
 
+        this.filtered = this.props.filterFunctions.length === 0
+            ? emoji
+            : _.pickBy(emoji, value => _.every(this.props.filterFunctions, fn => fn(value)))
         this.emoji = [];
         let categoryIndexMap = _(category)
             .map((v, idx) => ({ ...v, idx }))
@@ -298,7 +301,7 @@ class EmojiInput extends React.PureComponent {
             .map((v, k) => [
                 { char: category[k].key, categoryMarker: true, ...category[k] }
             ]);
-        _(emoji)
+        _(this.filtered)
             .values()
             .each(e => {
                 if (_.has(categoryIndexMap, e.category)) {
@@ -633,7 +636,8 @@ EmojiInput.defaultProps = {
     },
     emojiFontSize: 40,
     categoryFontSize: 20,
-    resetSearch: false
+    resetSearch: false,
+    filterFunctions: []
 };
 
 EmojiInput.propTypes = {
@@ -657,7 +661,8 @@ EmojiInput.propTypes = {
     enableFrequentlyUsedEmoji: PropTypes.bool,
     numFrequentlyUsedEmoji: PropTypes.number,
     defaultFrequentlyUsedEmoji: PropTypes.arrayOf(PropTypes.string),
-    resetSearch: PropTypes.bool
+    resetSearch: PropTypes.bool,
+    filterFunctions: PropTypes.arrayOf(PropTypes.func)
 };
 
 const styles = {

--- a/example/src/EmojiInput.js
+++ b/example/src/EmojiInput.js
@@ -282,14 +282,12 @@ class EmojiInput extends React.PureComponent {
         }
     };
 
-    emojiRenderer = emoji => {
+    emojiRenderer = emojis => {
         let dataProvider = new DataProvider((e1, e2) => {
             return e1.char !== e2.char;
         });
 
-        this.filtered = this.props.filterFunctions.length === 0
-            ? emoji
-            : _.pickBy(emoji, value => _.every(this.props.filterFunctions, fn => fn(value)))
+        this.filteredEmojis = _(emojis).pickBy(emoji => _.every(this.props.filterFunctions, fn => fn(emoji)))
         this.emoji = [];
         let categoryIndexMap = _(category)
             .map((v, idx) => ({ ...v, idx }))
@@ -301,7 +299,7 @@ class EmojiInput extends React.PureComponent {
             .map((v, k) => [
                 { char: category[k].key, categoryMarker: true, ...category[k] }
             ]);
-        _(this.filtered)
+        _(this.filteredEmojis)
             .values()
             .each(e => {
                 if (_.has(categoryIndexMap, e.category)) {

--- a/example/src/EmojiInput.js
+++ b/example/src/EmojiInput.js
@@ -287,7 +287,6 @@ class EmojiInput extends React.PureComponent {
             return e1.char !== e2.char;
         });
 
-        this.filteredEmojis = _(emojis).pickBy(emoji => _.every(this.props.filterFunctions, fn => fn(emoji))).value();
         this.emoji = [];
         let categoryIndexMap = _(category)
             .map((v, idx) => ({ ...v, idx }))
@@ -299,8 +298,9 @@ class EmojiInput extends React.PureComponent {
             .map((v, k) => [
                 { char: category[k].key, categoryMarker: true, ...category[k] }
             ]);
-        _(this.filteredEmojis)
+        _(emojis)
             .values()
+            .filter(emoji => _.every(this.props.filterFunctions, fn => fn(emoji)))
             .each(e => {
                 if (_.has(categoryIndexMap, e.category)) {
                     tempEmoji[categoryIndexMap[e.category].idx].push(e);

--- a/example/src/EmojiInput.js
+++ b/example/src/EmojiInput.js
@@ -287,7 +287,7 @@ class EmojiInput extends React.PureComponent {
             return e1.char !== e2.char;
         });
 
-        this.filteredEmojis = _(emojis).pickBy(emoji => _.every(this.props.filterFunctions, fn => fn(emoji)))
+        this.filteredEmojis = _(emojis).pickBy(emoji => _.every(this.props.filterFunctions, fn => fn(emoji))).value();
         this.emoji = [];
         let categoryIndexMap = _(category)
             .map((v, idx) => ({ ...v, idx }))

--- a/src/EmojiInput.js
+++ b/src/EmojiInput.js
@@ -287,6 +287,9 @@ class EmojiInput extends React.PureComponent {
             return e1.char !== e2.char;
         });
 
+        this.filtered = this.props.filterFunctions.length === 0
+            ? emoji
+            : _.pickBy(emoji, value => _.every(this.props.filterFunctions, fn => fn(value)))
         this.emoji = [];
         let categoryIndexMap = _(category)
             .map((v, idx) => ({ ...v, idx }))
@@ -298,7 +301,7 @@ class EmojiInput extends React.PureComponent {
             .map((v, k) => [
                 { char: category[k].key, categoryMarker: true, ...category[k] }
             ]);
-        _(emoji)
+        _(this.filtered)
             .values()
             .each(e => {
                 if (_.has(categoryIndexMap, e.category)) {
@@ -633,7 +636,8 @@ EmojiInput.defaultProps = {
     },
     emojiFontSize: 40,
     categoryFontSize: 20,
-    resetSearch: false
+    resetSearch: false,
+    filterFunctions: []
 };
 
 EmojiInput.propTypes = {
@@ -657,7 +661,8 @@ EmojiInput.propTypes = {
     enableFrequentlyUsedEmoji: PropTypes.bool,
     numFrequentlyUsedEmoji: PropTypes.number,
     defaultFrequentlyUsedEmoji: PropTypes.arrayOf(PropTypes.string),
-    resetSearch: PropTypes.bool
+    resetSearch: PropTypes.bool,
+    filterFunctions: PropTypes.arrayOf(PropTypes.func)
 };
 
 const styles = {

--- a/src/EmojiInput.js
+++ b/src/EmojiInput.js
@@ -282,14 +282,12 @@ class EmojiInput extends React.PureComponent {
         }
     };
 
-    emojiRenderer = emoji => {
+    emojiRenderer = emojis => {
         let dataProvider = new DataProvider((e1, e2) => {
             return e1.char !== e2.char;
         });
 
-        this.filtered = this.props.filterFunctions.length === 0
-            ? emoji
-            : _.pickBy(emoji, value => _.every(this.props.filterFunctions, fn => fn(value)))
+        this.filteredEmojis = _(emojis).pickBy(emoji => _.every(this.props.filterFunctions, fn => fn(emoji)))
         this.emoji = [];
         let categoryIndexMap = _(category)
             .map((v, idx) => ({ ...v, idx }))
@@ -301,7 +299,7 @@ class EmojiInput extends React.PureComponent {
             .map((v, k) => [
                 { char: category[k].key, categoryMarker: true, ...category[k] }
             ]);
-        _(this.filtered)
+        _(this.filteredEmojis)
             .values()
             .each(e => {
                 if (_.has(categoryIndexMap, e.category)) {

--- a/src/EmojiInput.js
+++ b/src/EmojiInput.js
@@ -287,7 +287,6 @@ class EmojiInput extends React.PureComponent {
             return e1.char !== e2.char;
         });
 
-        this.filteredEmojis = _(emojis).pickBy(emoji => _.every(this.props.filterFunctions, fn => fn(emoji))).value();
         this.emoji = [];
         let categoryIndexMap = _(category)
             .map((v, idx) => ({ ...v, idx }))
@@ -299,8 +298,9 @@ class EmojiInput extends React.PureComponent {
             .map((v, k) => [
                 { char: category[k].key, categoryMarker: true, ...category[k] }
             ]);
-        _(this.filteredEmojis)
+        _(emojis)
             .values()
+            .filter(emoji => _.every(this.props.filterFunctions, fn => fn(emoji)))
             .each(e => {
                 if (_.has(categoryIndexMap, e.category)) {
                     tempEmoji[categoryIndexMap[e.category].idx].push(e);

--- a/src/EmojiInput.js
+++ b/src/EmojiInput.js
@@ -287,7 +287,7 @@ class EmojiInput extends React.PureComponent {
             return e1.char !== e2.char;
         });
 
-        this.filteredEmojis = _(emojis).pickBy(emoji => _.every(this.props.filterFunctions, fn => fn(emoji)))
+        this.filteredEmojis = _(emojis).pickBy(emoji => _.every(this.props.filterFunctions, fn => fn(emoji))).value();
         this.emoji = [];
         let categoryIndexMap = _(category)
             .map((v, idx) => ({ ...v, idx }))


### PR DESCRIPTION
# Relate to any issue?
https://github.com/sskhandek/react-native-emoji-input/issues/5  
It is a temporary workaround that would allow user of this library to avoid missing emojis being render as `X`

# Breaking change?
Nope, by default all emojis will be rendered as before.

# What this PR does?  
Adds new `filterFunctions` prop allowing user to pass an array of functions used to filter emojis list before rendering it

# Example of usage:
```
	filterFunctionByUnicode = emoji => {
		return emoji.lib.added_in === "6.0" || emoji.lib.added_in === "6.1"
	}

	<EmojiInput
		onEmojiSelected={this.handleEmojiSelected}
		ref={emojiInput => this._emojiInput = emojiInput}
		resetSearch={this.state.reset}
		loggingFunction={this.verboseLoggingFunction.bind(this)}
		verboseLoggingFunction={true}
		filterFunctions={[this.filterFunctionByUnicode]}
	/>
```

# Change Preview:  
**Before on my Huawei P8Lite running Android 6.0**:  
![before](https://user-images.githubusercontent.com/11317951/53982863-41c49900-4116-11e9-985b-83044d0ded04.png)

**After enabling only 6.0 Unicode**:  
![after](https://user-images.githubusercontent.com/11317951/53982900-543ed280-4116-11e9-9ade-6363a4858b03.png)
